### PR TITLE
Switch comments provider from utterances to Disqus

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,12 +46,9 @@ social:
 
 # Google Analytics, Comments, Adsense etc.
 comments:
-  provider: utterances
-  utterances:
-    repo: zorba-lim/zorba-lim.github.io
-    issue_term: pathname
-    theme: github-light
-    label: comment
+  provider: disqus
+  disqus:
+    shortname: zorba-lim-github-io
 
 # TOC
 toc: true


### PR DESCRIPTION
### Motivation
- Replace GitHub-login-only `utterances` comments with `disqus` so visitors can post comments without requiring a GitHub account.

### Description
- Update `_config.yml` to set `comments.provider: disqus`, remove `utterances`-specific options, and add `disqus.shortname: zorba-lim-github-io`.

### Testing
- Parsed `_config.yml` successfully with Ruby YAML loader using `ruby -e "require 'yaml'; YAML.load_file('_config.yml')"` which printed `YAML OK`.
- Attempted to parse with Python (`PyYAML`) but the environment lacked `yaml` so that check failed due to missing module.
- Committed the change with `git commit` which succeeded (1 file changed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69992493d30c8321a4d1ff315ef6d4f5)