### PR TITLE
Enable Google AdSense Auto Ads loader

### DIFF
--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -18,3 +18,7 @@
         }
     });
 </script>
+
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9677120965646002" crossorigin="anonymous"></script>
+
+<meta name="google-adsense-account" content="ca-pub-9677120965646002">


### PR DESCRIPTION
### Motivation
- The previous change added only the AdSense account meta tag but Auto Ads require loading the AdSense JavaScript with the publisher client ID so ads can render automatically.

### Description
- Added the official AdSense Auto Ads loader script tag `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9677120965646002` with `async` and `crossorigin="anonymous"` to ` _includes/metadata-hook.html`.
- Kept the existing `meta` tag `google-adsense-account` and preserved the TOC initialization script in place.
- Placed the script immediately after the TOC script block so it is included in the page head alongside the account meta tag.

### Testing
- Verified the updated file contents using `nl -ba _includes/metadata-hook.html | sed -n '1,220p'` and confirmed the new script and meta tag are present.
- Confirmed the repository contains the updated ` _includes/metadata-hook.html` file with the expected changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999bb55a3588321b14a072d67756663)