### PR TITLE
Add ads.txt and include AdSense Auto Ads loader/meta tag

### DIFF
--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -18,3 +18,7 @@
         }
     });
 </script>
+
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9677120965646002" crossorigin="anonymous"></script>
+
+<meta name="google-adsense-account" content="ca-pub-9677120965646002">

--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9677120965646002, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
### Motivation
- AdSense reported a missing `ads.txt` which can reduce ad demand and prevent seller verification. 
- Auto Ads require the AdSense loader script with the publisher client ID and a meta/account entry in the page head to enable automatic ad serving.

### Description
- Added a root-level `ads.txt` containing the Google AdSense authorized seller entry: `google.com, pub-9677120965646002, DIRECT, f08c47fec0942fa0`.
- Inserted the official AdSense Auto Ads loader script tag `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9677120965646002` with `async` and `crossorigin="anonymous"` into `_includes/metadata-hook.html`.
- Added a meta tag `google-adsense-account` with the publisher ID in `_includes/metadata-hook.html` to pair with the loader script.

### Testing
- Verified the new `ads.txt` contents with `nl -ba ads.txt` and confirmed the expected line was present.
- Confirmed the working tree state and commit with `git status --short` and `git rev-parse --short HEAD`, and committed the new `ads.txt` file.
- Confirmed the `_includes/metadata-hook.html` changes are present in the diff that adds the loader script and meta tag.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999bb55a3588321b14a072d67756663)