### PR TITLE
Set production Google Search Console verification token

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,10 @@ social:
     - https://github.com/zorba-lim
 
 # Google Analytics, Comments, Adsense etc.
+# Search Console verification
+webmaster_verifications:
+  google: "4KZYmtKZD1z3ShpJmxI3_WgD9dwbUrsEULitvWh3xB4"
+
 comments:
   provider: disqus
   disqus:

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://zorba-lim.github.io/sitemap.xml


### PR DESCRIPTION
### Motivation
- Replace the placeholder Google Search Console token with the provided production token so the Jekyll SEO tag can emit a valid Google verification meta tag and crawlers can still find the sitemap.

### Description
- Update `_config.yml` to set `webmaster_verifications.google` to the provided token `4KZYmtKZD1z3ShpJmxI3_WgD9dwbUrsEULitvWh3xB4`, while leaving the previously added `robots.txt` sitemap entry unchanged.

### Testing
- Validated the presence of the verification token and sitemap entry by running `rg -n "webmaster_verifications|google-site-verification|Sitemap:" _config.yml robots.txt` and inspected the file regions with `nl -ba _config.yml | sed -n '46,54p'; nl -ba robots.txt | sed -n '1,6p'`, both of which showed the expected values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999c49b2df08321b15c60dcd91b6315)