### PR TITLE
Rewrite 10 posts with topic-specific content and remove Google Trends labeling

### DIFF
--- a/_posts/2026-02-22-google-trends-01-ai-agent-boom.md
+++ b/_posts/2026-02-22-google-trends-01-ai-agent-boom.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "실무자들 비상(?) 🤖 AI 에이전트가 회의록까지 써주는 시대"
+date: 2026-02-22 12:00:00 +0900
+categories: [News, Global, Insight]
+tags: [ai-agent, productivity, automation]
+description: "AI 에이전트 확산과 업무 자동화 변화"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+AI 에이전트는 질문에 답만 하는 도구를 넘어, 일정 정리·메일 초안·자료 요약처럼 여러 단계를 스스로 이어서 처리하는 방식으로 빠르게 확산되고 있어요. 최근 기업들은 고객 응대 챗봇을 에이전트형으로 바꾸며 문의 분류, 답변 초안, 담당자 전달까지 자동화하고 있습니다. 개인 사용자도 여행 일정 만들기, 비교표 작성, 코드 수정 같은 반복 업무를 줄이는 데 활용 중이에요. 다만 정확도 검증 없이 결과를 그대로 쓰면 오류가 커질 수 있어, 최종 확인 책임은 사람에게 남아 있습니다. 핵심은 “더 빨리”보다 “더 정확하게”입니다. 에이전트를 도입할 때는 업무 범위를 좁게 시작하고, 검수 기준·로그 기록·권한 설정을 먼저 정하는 팀이 성과를 안정적으로 내고 있습니다.
+
+## 🎓 용어 설명 (KR)
+
+- **에이전트 워크플로우**: 여러 작업을 순서대로 연결해 자동 실행하는 구조
+- **휴먼 인 더 루프(HITL)**: 중요한 단계에서 사람이 최종 승인하는 방식
+- **프롬프트 가드레일**: 모델이 벗어나면 안 되는 규칙/제약 조건
+
+## 🧠 퀴즈 (KR)
+
+Q. 업무용 AI 에이전트를 도입할 때 가장 먼저 정해야 할 것은?
+
+1) 화려한 UI 색상
+2) 검수 기준과 권한 범위
+3) 사내 밈(Meme) 목록
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+AI agents are moving from simple Q&A to multi-step execution (summarize, draft, route, and report). Teams see better results when they start small, define review checkpoints, and keep humans accountable for final decisions.
+
+## 🔗 참고 링크
+
+- OpenAI guide (agents): https://platform.openai.com/docs/guides/agents
+- Google Cloud architecture for AI agents: https://cloud.google.com/architecture
+- Harvard Business Review (AI at work): https://hbr.org/topic/artificial-intelligence

--- a/_posts/2026-02-22-google-trends-02-us-election.md
+++ b/_posts/2026-02-22-google-trends-02-us-election.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "정치 뉴스가 경제를 흔든다 🗳️ 미국 대선, 왜 다들 촉각 곤두세울까?"
+date: 2026-02-22 13:00:00 +0900
+categories: [News, Global, Insight]
+tags: [us-election, politics, global]
+description: "미국 대선 이슈와 글로벌 파급력"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+미국 대선 이슈가 뜨거워질 때마다 국내에서도 환율, 금리, 반도체, 방산 같은 키워드 검색이 함께 늘어납니다. 이유는 단순해요. 미국의 통상 정책과 대외 전략은 글로벌 공급망과 자본 흐름에 직접 영향을 주기 때문입니다. 예를 들어 관세 강화 신호가 나오면 수출 기업 실적 전망이 흔들리고, 금리 관련 발언이 나오면 달러 강세 기대가 커지기도 하죠. 그래서 선거 보도는 “누가 이길까”보다 “어떤 정책 조합이 현실화될까”를 읽는 게 더 중요합니다. 정책 공약은 선거 과정에서 바뀌는 경우가 많아, 토론 발언·캠프 발표·의회 지형을 함께 보는 습관이 필요합니다. 정치 이벤트를 경제 지표와 연결해서 읽으면 훨씬 현실적인 판단이 가능합니다.
+
+## 🎓 용어 설명 (KR)
+
+- **스윙 스테이트**: 승패를 가를 가능성이 큰 경합 주
+- **통상 정책**: 국가 간 무역 규칙·관세·규제 관련 정책
+- **리스크 프리미엄**: 불확실성 때문에 요구되는 추가 수익률
+
+## 🧠 퀴즈 (KR)
+
+Q. 선거 뉴스를 실무적으로 볼 때 가장 유효한 관점은?
+
+1) 후보의 별명
+2) 정책의 실행 가능성과 의회 구도
+3) 유세장 배경음악
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+U.S. election coverage matters globally because policy signals can move trade, rates, and FX expectations. Focus less on campaign drama and more on policy feasibility, congressional dynamics, and market transmission paths.
+
+## 🔗 참고 링크
+
+- Federal Reserve: https://www.federalreserve.gov/
+- Reuters U.S. politics: https://www.reuters.com/world/us/
+- Council on Foreign Relations: https://www.cfr.org/

--- a/_posts/2026-02-22-google-trends-03-bitcoin.md
+++ b/_posts/2026-02-22-google-trends-03-bitcoin.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "심장 쫄깃 투자 주의보 💸 비트코인, 숫자보다 사이클을 보자"
+date: 2026-02-22 14:00:00 +0900
+categories: [News, Global, Insight]
+tags: [bitcoin, etf, finance]
+description: "비트코인 변동성과 투자 체크포인트"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+비트코인은 단기간 급등·급락이 반복되는 대표 자산입니다. 최근에는 제도권 자금 유입 기대, 거시 금리 방향, 규제 뉴스가 가격을 크게 흔들고 있어요. 특히 “상승 이유”가 기술 혁신인지 유동성 효과인지 구분하지 않으면 타이밍 판단이 어려워집니다. 초보 투자자일수록 가격만 보지 말고 거래량, 변동성, 온체인 지표를 함께 확인해야 해요. 또 한 번에 크게 매수하기보다 분할 접근과 손절 기준을 미리 정하는 것이 중요합니다. 장기적으로는 블록체인 인프라 성장이라는 구조적 스토리가 있지만, 단기 구간에서는 뉴스 한 줄에 방향이 바뀔 수 있습니다. 결국 핵심은 확신이 아니라 규칙입니다. 본인 자산 배분 원칙 안에서 감당 가능한 범위로 접근하는 태도가 필요합니다.
+
+## 🎓 용어 설명 (KR)
+
+- **온체인 지표**: 블록체인 네트워크에서 직접 수집한 거래 데이터
+- **변동성**: 가격이 일정 기간 얼마나 크게 움직이는지 나타내는 정도
+- **분할 매수**: 한 번에 사지 않고 여러 시점으로 나눠 매수하는 전략
+
+## 🧠 퀴즈 (KR)
+
+Q. 변동성이 큰 자산에서 초보자에게 가장 중요한 원칙은?
+
+1) 한 번에 풀매수
+2) 진입·손절 규칙을 미리 정하기
+3) 커뮤니티 분위기 따라가기
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+Bitcoin can reprice quickly on liquidity, regulation, and macro-rate signals. For risk control, define entry and exit rules before trading and avoid oversized positions driven by short-term hype.
+
+## 🔗 참고 링크
+
+- CoinDesk Markets: https://www.coindesk.com/markets/
+- BIS crypto reports: https://www.bis.org/
+- Investopedia Bitcoin basics: https://www.investopedia.com/terms/b/bitcoin.asp

--- a/_posts/2026-02-22-google-trends-04-champions-league.md
+++ b/_posts/2026-02-22-google-trends-04-champions-league.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "새벽잠 순삭 ⚽ 챔피언스리그, 전술 한 수가 시즌을 바꾼다"
+date: 2026-02-22 15:00:00 +0900
+categories: [News, Global, Insight]
+tags: [champions-league, football, sports]
+description: "챔피언스리그 전술 포인트와 관전 재미"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+챔피언스리그 토너먼트가 시작되면 경기력은 이름값보다 디테일에서 갈립니다. 강팀도 원정에서 수비 라인을 내리고, 약팀도 세트피스 하나로 흐름을 뒤집죠. 최근 화제는 전방 압박 강도와 풀백의 인버티드 움직임이에요. 공을 뺏은 뒤 10초 안에 슈팅까지 연결하는 팀이 기대득점(xG)에서 우위를 가져가는 장면이 자주 보입니다. 팬 입장에서는 득점 장면만 보지 말고, 빌드업 출발 위치와 압박 트리거를 보면 경기가 훨씬 재미있어요. 또 2차전 합산 스코어 규칙 때문에 1차전의 한 골이 전술 전체를 바꾸기도 합니다. 결국 유럽 무대는 스타 개인기와 조직 전술이 동시에 맞물릴 때 가장 폭발적인 결과가 나옵니다.
+
+## 🎓 용어 설명 (KR)
+
+- **xG(기대득점)**: 슈팅 위치·상황을 기반으로 득점 확률을 수치화한 지표
+- **인버티드 풀백**: 측면 수비수가 중앙 미드필더처럼 안쪽으로 들어오는 역할
+- **압박 트리거**: 상대가 특정 패스를 할 때 압박을 시작하는 약속 신호
+
+## 🧠 퀴즈 (KR)
+
+Q. 토너먼트 경기에서 흐름을 읽는 데 가장 유용한 관전 포인트는?
+
+1) 선수 헤어스타일
+2) 빌드업 위치와 압박 타이밍
+3) 응원가 음정
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+In Champions League knockout matches, details decide outcomes: pressing triggers, buildup zones, and role rotations often matter more than star power alone.
+
+## 🔗 참고 링크
+
+- UEFA Champions League: https://www.uefa.com/uefachampionsleague/
+- The Athletic football tactics: https://www.nytimes.com/athletic/football/
+- StatsBomb blog: https://statsbomb.com/articles/football/

--- a/_posts/2026-02-22-google-trends-05-kpop-comeback.md
+++ b/_posts/2026-02-22-google-trends-05-kpop-comeback.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "팬심 폭주 모드 🎤 K-팝 컴백 시즌, 기록은 어떻게 만들어질까?"
+date: 2026-02-22 16:00:00 +0900
+categories: [News, Global, Insight]
+tags: [kpop, comeback, music]
+description: "K-팝 컴백 전략과 팬덤 문화 분석"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+K-팝 컴백 시즌에는 티저 공개 2주 전부터 검색량과 팬 커뮤니티 활동이 동시에 올라갑니다. 이번 흐름의 핵심은 “스토리형 프로모션”이에요. 뮤직비디오 세계관 단서, 숏폼 챌린지, 라이브 클립을 단계적으로 배치해 팬 참여를 끌어올리는 방식입니다. 성적을 볼 때는 조회수 하나만 보지 말고 음원 유지율, 해외 플레이리스트 진입, 콘서트 전환율까지 함께 보는 게 정확해요. 특히 글로벌 팬덤이 큰 팀일수록 번역·자막·현지 플랫폼 운영이 성과를 좌우합니다. 팬 입장에서는 무리한 소비 경쟁보다 지속 가능한 응원 방식이 중요하고, 산업 측면에서는 아티스트 건강 관리와 제작 일정의 균형이 장기 경쟁력으로 연결됩니다. 결국 컴백은 한 곡 발표가 아니라 브랜드 운영의 총합입니다.
+
+## 🎓 용어 설명 (KR)
+
+- **티저 드롭(Teaser drop)**: 정식 공개 전 단계적으로 미리 푸는 홍보 콘텐츠
+- **유지율(Retention)**: 초기 반응 이후 관심이 얼마나 오래 유지되는지 보여주는 지표
+- **UGC(User Generated Content)**: 팬이 직접 만든 2차 창작 콘텐츠
+
+## 🧠 퀴즈 (KR)
+
+Q. 컴백 성과를 더 정확히 보기 위한 방법은?
+
+1) 첫날 조회수만 보기
+2) 음원 유지율·해외 확산·공연 전환을 함께 보기
+3) 포토카드 종류만 세기
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+K-pop comebacks now rely on story-driven campaigns across teasers, short-form content, and fan-generated media. Sustainable growth is measured by retention and global conversion, not day-one numbers alone.
+
+## 🔗 참고 링크
+
+- IFPI Global Music Report: https://ifpi.org/
+- Billboard K-pop: https://www.billboard.com/c/k-pop/
+- YouTube Culture & Trends: https://cultureandtrends.withgoogle.com/

--- a/_posts/2026-02-22-google-trends-06-heatwave.md
+++ b/_posts/2026-02-22-google-trends-06-heatwave.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "봄인데 에어컨 찾는 중 🌡️ 폭염의 조기 등장, 우리 일상은 안전할까?"
+date: 2026-02-22 17:00:00 +0900
+categories: [News, Global, Insight]
+tags: [climate, heatwave, environment]
+description: "이상고온·폭염 대응과 생활 안전 가이드"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+최근 봄철인데도 한낮 기온이 빠르게 오르며 조기 폭염 우려가 커지고 있습니다. 기온 자체보다 위험한 건 체감온도와 야간 최저기온이에요. 밤에도 열이 식지 않으면 수면 질이 떨어지고, 고령층·야외근로자 건강 부담이 크게 늘어납니다. 생활 대응은 생각보다 단순합니다. 물을 “목마를 때”가 아니라 일정 간격으로 마시고, 오후 2~5시 야외 활동을 줄이며, 실내 환기는 짧고 자주 하는 방식이 효과적입니다. 지방자치단체의 무더위 쉼터, 재난 문자, 폭염특보 앱 알림도 꼭 켜 두세요. 학교와 직장에서는 냉방 여부만이 아니라 휴식 시간, 복장 기준, 작업 강도 조절 같은 운영 규칙이 중요합니다. 기후 이슈는 뉴스가 아니라 생활 매뉴얼이라는 인식 전환이 필요합니다.
+
+## 🎓 용어 설명 (KR)
+
+- **체감온도**: 기온·습도·바람을 반영해 사람이 실제로 느끼는 더위 정도
+- **열대야**: 밤 최저기온이 높은 상태가 지속되는 현상
+- **폭염특보**: 일정 기준 이상의 더위가 예상될 때 발령되는 기상 경보
+
+## 🧠 퀴즈 (KR)
+
+Q. 폭염 대응에서 가장 효과적인 기본 습관은?
+
+1) 갈증 날 때만 물 마시기
+2) 정해진 간격으로 수분 보충하기
+3) 점심 시간 야외 운동 늘리기
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+Early heatwaves increase health risks before people adapt. Practical protection includes scheduled hydration, reduced peak-hour outdoor exposure, and local heat alert monitoring.
+
+## 🔗 참고 링크
+
+- World Meteorological Organization: https://wmo.int/
+- KMA weather alerts: https://www.weather.go.kr/
+- WHO climate and health: https://www.who.int/health-topics/climate-change

--- a/_posts/2026-02-22-google-trends-07-ev-battery.md
+++ b/_posts/2026-02-22-google-trends-07-ev-battery.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "충전보다 관리가 핵심 🔋 전기차 배터리 수명, 진짜 아끼는 법"
+date: 2026-02-22 18:00:00 +0900
+categories: [News, Global, Insight]
+tags: [ev, battery, mobility]
+description: "전기차 배터리 성능 유지와 관리 팁"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+전기차 배터리 이슈의 핵심은 “얼마나 오래 가느냐”입니다. 주행거리만큼 중요한 것이 충전 습관과 온도 관리예요. 일반적으로 배터리는 극단적인 고온·저온, 잦은 100% 완충 상태에서 스트레스를 받습니다. 그래서 일상 주행은 20~80% 범위 운영을 권장하는 경우가 많고, 장거리 전에는 완충을 활용하되 출발 시점에 맞추는 것이 좋아요. 급속충전은 편리하지만 연속 사용 빈도를 조절하면 열화를 줄일 수 있습니다. 중고 전기차를 볼 때는 단순 연식보다 배터리 상태지표(SOH), 충전 이력, 보증 조건을 확인해야 합니다. 제조사 소프트웨어 업데이트도 효율에 영향을 주므로 정기 점검이 중요해요. 결론적으로 배터리는 소모품이지만, 관리 방식에 따라 체감 수명이 크게 달라집니다.
+
+## 🎓 용어 설명 (KR)
+
+- **SOH(State of Health)**: 배터리의 현재 건강 상태를 나타내는 지표
+- **완속/급속 충전**: 전력 공급 속도에 따른 충전 방식 구분
+- **열화(Degradation)**: 사용 시간에 따라 배터리 성능이 감소하는 현상
+
+## 🧠 퀴즈 (KR)
+
+Q. 배터리 수명 관리에 상대적으로 유리한 습관은?
+
+1) 항상 100%로 오래 주차
+2) 일상은 권장 충전 구간 중심으로 운영
+3) 급속충전만 연속 사용
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+EV battery longevity depends heavily on charging patterns and thermal conditions. For daily use, moderate charge windows and heat management generally improve long-term performance.
+
+## 🔗 참고 링크
+
+- IEA Global EV Outlook: https://www.iea.org/reports/global-ev-outlook-2025
+- U.S. DOE EV basics: https://afdc.energy.gov/vehicles/electric_basics.html
+- Nature Energy (battery research): https://www.nature.com/nenergy/

--- a/_posts/2026-02-22-google-trends-08-moon-base.md
+++ b/_posts/2026-02-22-google-trends-08-moon-base.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "달에 집 짓기 프로젝트 🚀 공상과학이 아니라 일정표가 됐다"
+date: 2026-02-22 19:00:00 +0900
+categories: [News, Global, Insight]
+tags: [moon, nasa, space]
+description: "달 기지 프로젝트와 우주 산업 변화"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+달 기지 프로젝트는 더 이상 상징 경쟁이 아니라 기술·산업·외교가 결합된 장기 계획으로 바뀌고 있습니다. 핵심 목표는 달 표면에서 장기 체류 기술을 검증하고, 향후 화성 탐사 전초기지를 만드는 것이에요. 물 얼음 자원 탐사, 방사선 차폐, 에너지 공급, 통신 지연 대응 같은 문제를 해결해야 실제 거주가 가능합니다. 민간 기업도 착륙선, 로버, 우주복, 보급 시스템에 참여하면서 우주 생태계가 빠르게 넓어지고 있죠. 일반 독자에게 중요한 포인트는 “우주 뉴스=먼 이야기”가 아니라는 점입니다. 위성 통신, 소재 기술, 로봇 제어 같은 파생 기술이 지상 산업으로 내려와 새로운 일자리를 만들기 때문입니다. 결국 달 기지는 과학 이벤트이자 미래 산업 테스트베드입니다.
+
+## 🎓 용어 설명 (KR)
+
+- **ISRU(In-Situ Resource Utilization)**: 현지 자원을 채굴·가공해 사용하는 기술
+- **차폐(Shielding)**: 방사선·미세운석으로부터 구조물을 보호하는 기술
+- **심우주 통신**: 지구-달/행성 간 장거리 데이터 통신 체계
+
+## 🧠 퀴즈 (KR)
+
+Q. 달 기지 프로젝트의 실질적 의미로 가장 적절한 것은?
+
+1) 기념 사진 촬영
+2) 장기 체류 기술 검증과 산업 파급
+3) 망원경 판매 행사
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+Moon-base programs are becoming long-horizon engineering platforms, not one-off missions. They test life-support, resource use, and autonomous operations with strong spillover into Earth industries.
+
+## 🔗 참고 링크
+
+- NASA Artemis: https://www.nasa.gov/humans-in-space/artemis/
+- ESA Moon exploration: https://www.esa.int/Science_Exploration/Human_and_Robotic_Exploration/Exploration/Moon_exploration
+- UN Office for Outer Space Affairs: https://www.unoosa.org/

--- a/_posts/2026-02-22-google-trends-09-glp1.md
+++ b/_posts/2026-02-22-google-trends-09-glp1.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "식욕 스위치를 건드린다? 🧬 GLP-1 이슈, 기대와 오해 사이"
+date: 2026-02-22 20:00:00 +0900
+categories: [News, Global, Insight]
+tags: [glp1, health, medicine]
+description: "GLP-1 계열 약물의 효과와 주의사항"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+GLP-1 계열 치료는 혈당 조절과 체중 관리에서 주목받으며 의료·소비 시장 모두에서 큰 관심을 받고 있습니다. 다만 “유행 다이어트”처럼 단순 소비재로 접근하면 부작용 위험이 커질 수 있어요. 이 약물은 식욕 조절과 위 배출 속도에 영향을 주기 때문에 개인의 기저질환, 복용 이력, 생활습관에 따라 반응이 다르게 나타납니다. 초기에는 메스꺼움·소화 불편 같은 증상이 보고되기도 하며, 의료진 상담 없이 용량을 조절하는 건 위험합니다. 핵심은 약 하나로 끝내는 게 아니라 식단·수면·운동을 함께 맞추는 장기 관리 전략입니다. 관련 정보를 볼 때는 SNS 후기보다 학회 가이드라인, 규제기관 공지, 임상 근거 수준을 우선 확인하는 태도가 필요합니다.
+
+## 🎓 용어 설명 (KR)
+
+- **GLP-1**: 혈당과 식욕 조절에 관여하는 호르몬 경로
+- **임상 근거 수준**: 연구 설계와 표본 규모에 따라 신뢰도를 평가하는 기준
+- **부작용 프로파일**: 약물 복용 시 관찰되는 이상반응의 유형과 빈도
+
+## 🧠 퀴즈 (KR)
+
+Q. GLP-1 관련 정보를 확인할 때 가장 우선할 기준은?
+
+1) SNS 후기 조회수
+2) 공식 가이드라인과 의료진 상담
+3) 광고 문구의 강도
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+GLP-1 therapies can be effective, but outcomes and side effects vary by patient context. Clinical guidance and medical supervision should come before social-media anecdotes.
+
+## 🔗 참고 링크
+
+- FDA drug information: https://www.fda.gov/drugs
+- NEJM: https://www.nejm.org/
+- Korean Diabetes Association: https://www.diabetes.or.kr/

--- a/_posts/2026-02-22-google-trends-10-spring-travel.md
+++ b/_posts/2026-02-22-google-trends-10-spring-travel.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "벚꽃만 보지 마세요 🌸 봄 여행, 진짜 만족도는 동선에서 갈린다"
+date: 2026-02-22 21:00:00 +0900
+categories: [News, Global, Insight]
+tags: [spring-travel, tourism, lifestyle]
+description: "봄 여행 트렌드와 효율적인 일정 설계"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+봄 여행 시즌에는 유명 명소보다 “짧고 밀도 높은 일정”을 찾는 수요가 빠르게 늘어납니다. 교통 혼잡과 숙박비 상승을 고려하면, 여행 만족도는 사진 스팟보다 동선 설계에서 결정되는 경우가 많아요. 먼저 이동 시간을 기준으로 하루 코스를 2~3개 권역으로 나누고, 인기 장소는 오픈 직후·마감 직전 시간대를 노리면 대기 시간을 크게 줄일 수 있습니다. 식당도 평점만 보기보다 회전율, 예약 가능 시간, 대체 옵션을 같이 확인하는 게 좋아요. 가족·친구·혼행처럼 동행 유형에 따라 예산 배분도 달라집니다. 결국 좋은 여행은 “많이 보는 것”이 아니라 “덜 지치고 오래 기억되는 것”입니다. 이번 봄에는 체크리스트 기반으로 계획해 보세요: 이동·식사·휴식·예산 네 가지 축이면 충분합니다.
+
+## 🎓 용어 설명 (KR)
+
+- **동선 최적화**: 이동거리와 시간을 줄이도록 경로를 설계하는 것
+- **피크 타임**: 방문객이 집중되는 시간대
+- **혼행**: 다른 동행 없이 혼자 떠나는 여행 형태
+
+## 🧠 퀴즈 (KR)
+
+Q. 봄 여행 만족도를 높이는 핵심 전략은?
+
+1) 명소 개수만 최대화
+2) 이동·대기 시간을 고려한 동선 설계
+3) 즉흥적으로 아무 예약 없이 출발
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+For spring travel, satisfaction often comes from route design, not spot count. Plan around transit time, crowd windows, and backup options to keep energy and budget under control.
+
+## 🔗 참고 링크
+
+- UNWTO tourism data: https://www.unwto.org/statistics
+- Google Maps travel tips: https://blog.google/products/maps/
+- Korea Tourism Organization: https://kto.visitkorea.or.kr/


### PR DESCRIPTION
### Motivation

- Produce topic-specific, researched posts for the top trending keywords while removing any explicit "Google Trends"/"구글 트렌드" labeling. 
- Keep the site's expected post layout and engagement features (Korean article, glossary, hidden-answer quiz, brief English summary, and reference links). 
- Publish the posts in a clear sequential schedule to avoid template repetition and improve per-topic value.

### Description

- Rewrote the contents of 10 files under `_posts/` (files matching `2026-02-22-google-trends-*.md`) to replace the previous repeated template with differentiated, topic-focused articles and updated front matter. 
- Updated front matter titles/descriptions/tags and assigned sequential dates from `2026-02-22 12:00:00 +0900` through `2026-02-22 21:00:00 +0900`. 
- Ensured each post contains `## 🎓 용어 설명 (KR)`, `## 🧠 퀴즈 (KR)` with a `<details>` hidden-answer block, `## 🌍 English Brief`, and `## 🔗 참고 링크`, and committed the changes with the message `Rewrite 10 trend posts with topic-specific researched content`.

### Testing

- Ran `rg "구글 트렌드|Google Trends" _posts/2026-02-22-google-trends-*.md` and confirmed there are no remaining explicit mentions of Google Trends. 
- Executed a Python validation script that checked for the presence of the required sections in each file and reported `PASS`. 
- Verified repository state with `git status` and completed a `git commit` that modified 10 files, and noted that a local `jekyll build` could not be run in this environment due to missing dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999c2987a908321bd503b39a85c703e)