### PR TITLE
Add bilingual post on '왕과 사는 남자' with glossary and quiz

### DIFF
--- a/_posts/2026-02-22-king-and-his-man-history.md
+++ b/_posts/2026-02-22-king-and-his-man-history.md
@@ -1,0 +1,64 @@
+---
+layout: post
+title: "왕 옆에서 웃긴 죄? 🎭 영화 〈왕과 사는 남자〉로 읽는 연산군의 진짜 역사"
+date: 2026-02-22 19:30:00 +0900
+categories: [Movie, History, Korea]
+tags: [왕과사는남자, 왕의남자, 연산군, 조선사, 역사해설]
+description: "영화적 상상과 조선 연산군 시대의 역사적 사실을 함께 읽는 한·영 브리핑"
+---
+
+## 🎬 핵심 브리핑 (KR)
+
+요즘 다시 회자되는 영화 **〈왕과 사는 남자〉(많이 알려진 제목 〈왕의 남자〉로도 익숙한 작품)**는 궁중 광대의 시선으로 권력의 불안과 인간의 욕망을 보여줍니다. 작품 속 긴장감은 “왕이 절대 권력을 가졌지만, 동시에 가장 외로운 존재”라는 역설에서 출발하죠. 특히 연산군이 예술과 유희를 소비하는 방식, 그리고 신하·광대·백성을 대하는 태도는 조선 전기의 정치적 균열을 압축적으로 드러냅니다.
+
+역사적으로 연산군(재위 1494~1506)은 폭정의 상징으로 자주 기억되지만, 단순히 "잔혹한 왕" 한 줄로만 보면 당시 구조를 놓치기 쉽습니다. 무오사화·갑자사화처럼 대규모 숙청이 이어졌고, 언론 기능을 하던 삼사(사헌부·사간원·홍문관)가 약화되면서 견제 장치가 무너졌습니다. 결국 중종반정으로 폐위되며 조선 정치 질서는 "왕권의 한계"를 다시 설정하게 됩니다. 영화는 사실을 그대로 재현하기보다, 이 역사적 긴장을 **인물 감정과 상징**으로 번역해 보여준다고 볼 수 있습니다.
+
+한 줄로 정리하면: 이 영화의 재미는 "사실 100%"가 아니라, **역사적 진실(권력은 왜 무너지는가)**을 드라마로 날카롭게 체감하게 만드는 데 있습니다.
+
+## 🎓 용어 설명 (KR)
+
+- **연산군**: 조선 10대 왕. 반정으로 폐위되어 묘호(○○조)가 아닌 군(君)으로 불림.
+- **사화(士禍)**: 조선시대 사림이 정치적으로 대거 숙청된 사건.
+- **중종반정**: 1506년, 연산군을 몰아내고 중종을 옹립한 정치적 정변.
+- **삼사**: 왕권을 비판·견제하던 핵심 언론/감찰 기구(사헌부·사간원·홍문관).
+
+## 🧠 퀴즈 (KR)
+
+Q1. 연산군이 "왕"이 아니라 "군"으로 불리는 가장 큰 이유는 무엇일까요?
+
+1) 나이가 어려서  
+2) 반정으로 폐위되어 묘호를 받지 못해서  
+3) 전쟁에서 패배해서
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+Q2. 영화를 역사 콘텐츠로 볼 때 가장 적절한 태도는?
+
+A) 영화 장면을 전부 실록 사실로 간주한다  
+B) 영화는 감정과 상징, 실록은 사실 검증에 활용한다  
+C) 역사 기록은 볼 필요가 없다
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: B**
+
+</details>
+
+## 🌍 English Brief
+
+The film often referred to as **"The King and the Clown"** (here introduced as *"The Man Living with the King"* in Korean phrasing) portrays court entertainers trapped inside royal power games. Its real strength is not strict documentary accuracy, but emotional truth: absolute power can be both intoxicating and fragile.
+
+Historically, King Yeonsangun (r. 1494–1506) is remembered for purges and political repression. During his reign, institutional checks—especially the remonstration offices—were severely weakened. He was eventually deposed in the 1506 coup (Jungjong Restoration), which redefined limits on kingship in Joseon politics. So, the film works best as a gateway: feel the drama first, then verify details through primary and scholarly sources.
+
+## 🔗 참고 링크 / References
+
+- 한국민족문화대백과: 연산군 https://encykorea.aks.ac.kr/Article/E0036705
+- 한국사데이터베이스(조선왕조실록) https://sillok.history.go.kr
+- Encyclopaedia Britannica: Yeonsangun https://www.britannica.com/biography/Yeonsangun
+- KOFIC(영화정보) https://www.kobis.or.kr


### PR DESCRIPTION
### Motivation
- Provide a concise bilingual (Korean/English) briefing that connects the film 〈왕과 사는 남자〉/〈왕의 남자〉 to the historical record of King Yeonsangun and explain where filmic imagination departs from historical fact. 
- Match existing site post structure (briefing → glossary → quiz with hidden answers → English summary → references) for editorial consistency.

### Description
- Added a new post file `_posts/2026-02-22-king-and-his-man-history.md` containing frontmatter (title, date, categories, tags, description) and bilingual content. 
- Korean section summarizes the film’s themes and places them in historical context (Yeonsangun, purges/사화, weakening of 삼사, and 중종반정). 
- Included a glossary (`용어 설명`), two quiz questions with hidden answers using `<details>`, an English brief, and reference links to primary/scholarly sources. 

### Testing
- Ran `bundle exec jekyll build` to validate the site build, which failed due to a missing `jekyll` executable (`bundler: command not found: jekyll`).
- Verified the new post file contents with `nl -ba _posts/2026-02-22-king-and-his-man-history.md` and reviewed the inserted sections. 
- Checked repository status with `git status --short` to confirm the new file is present in the working tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699afdd0f7848321aae2abdae5a64461)