### PR TITLE
Correct '왕과 사는 남자' post to Danjong-era context

### DIFF
--- a/_posts/2026-02-22-king-and-his-man-history.md
+++ b/_posts/2026-02-22-king-and-his-man-history.md
@@ -1,0 +1,65 @@
+---
+layout: post
+title: "왕을 웃기다 역사를 울렸다 👑🎭 영화 〈왕과 사는 남자〉로 읽는 단종의 비극"
+date: 2026-02-22 19:30:00 +0900
+categories: [Movie, History, Korea]
+tags: [왕과사는남자, 단종, 세조, 사육신, 조선사]
+description: "2026년 2월 개봉 영화 〈왕과 사는 남자〉를 단종의 역사와 함께 읽는 한·영 포스팅"
+---
+
+## 🎬 핵심 브리핑 (KR)
+
+**2026년 2월 개봉작 〈왕과 사는 남자〉**는 왕권의 중심이 아니라, 그 곁에서 살아남아야 했던 사람들의 시선으로 궁궐의 공포와 침묵을 비춥니다. 특히 이 작품의 시대적 배경을 **단종** 시기로 놓고 보면, 영화 속 농담·침묵·눈치 같은 장치들이 단순한 연출이 아니라 “말 한마디가 목숨값이 되던 시대”를 드러내는 장면으로 읽힙니다.
+
+역사적으로 단종(재위 1452~1455)은 어린 나이에 즉위했지만, 숙부 수양대군(훗날 세조)에게 권력을 빼앗기며 폐위됩니다. 이후 상왕으로 강등되었다가 결국 노산군으로 유배되고 죽음에 이르렀죠. 이 과정에서 충신들의 복위 시도(대표적으로 사육신 사건)와 대규모 정치적 숙청이 이어졌고, 조선 초기 왕위 정통성 논쟁은 깊어졌습니다.
+
+영화는 실록을 그대로 옮기는 다큐멘터리가 아닙니다. 대신 "누가 역사를 기록하고, 누가 기록에서 지워지는가"라는 질문을 던집니다. 그래서 이 작품의 핵심 감상법은 간단합니다. **영화로 감정을 느끼고, 역사 기록으로 사실을 검증하기**. 두 층위를 함께 볼 때 단종 서사의 비극성과 당대 정치의 잔혹함이 더 선명해집니다.
+
+## 🎓 용어 설명 (KR)
+
+- **단종**: 조선 6대 왕. 어린 나이에 즉위했으나 계유정난 이후 폐위됨.
+- **세조(수양대군)**: 단종의 숙부. 정변을 통해 실권 장악 후 즉위.
+- **계유정난(1453)**: 수양대군이 정적을 제거하고 권력을 장악한 정치적 사건.
+- **사육신**: 단종 복위를 도모하다 처형된 충신들(성삼문, 박팽년 등).
+- **노산군**: 폐위된 뒤 단종에게 붙여진 호칭.
+
+## 🧠 퀴즈 (KR)
+
+Q1. 단종이 왕위에서 물러나게 되는 데 결정적 계기가 된 사건은?
+
+1) 임진왜란  
+2) 계유정난  
+3) 병자호란
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+Q2. 영화와 역사 기록을 함께 볼 때 가장 바람직한 태도는?
+
+A) 영화 대사를 그대로 역사 사실로 확정한다  
+B) 영화는 시대 감정의 창으로, 실록은 사실 검증 도구로 본다  
+C) 둘 다 필요 없다
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: B**
+
+</details>
+
+## 🌍 English Brief
+
+Released in **February 2026**, *The Man Living with the King* (Korean: 〈왕과 사는 남자〉) is best read against the tragedy of **King Danjong**. Rather than centering only on royal authority, the film highlights people who survived at the edge of power, where one wrong word could be fatal.
+
+Historically, Danjong (r. 1452–1455) was deposed after political upheaval led by his uncle, Grand Prince Suyang (later King Sejo), especially after the 1453 Gyeyu Coup. Efforts to restore Danjong, including the movement associated with the Sayuksin (Six Martyred Ministers), ended in brutal repression. The film is not a literal transcript of the Annals; it is a dramatic lens on fear, legitimacy, and erased voices.
+
+## 🔗 참고 링크 / References
+
+- 한국민족문화대백과: 단종 https://encykorea.aks.ac.kr/Article/E0014208
+- 한국민족문화대백과: 계유정난 https://encykorea.aks.ac.kr/Article/E0002824
+- 한국사데이터베이스(조선왕조실록) https://sillok.history.go.kr
+- Encyclopaedia Britannica: Danjong https://www.britannica.com/biography/Danjong


### PR DESCRIPTION
### Motivation
- Correct the historical framing of the previously added post from Yeonsangun to Danjong in accordance with feedback indicating the film is about 단종 and released in February 2026.  
- Ensure the post's explanatory layers (KR briefing, glossary, quiz, English brief, references) consistently reflect Danjong/세조/계유정난/사육신 context.  
- Keep the site post structure (briefing → glossary → quiz with hidden answers → English summary → references) while fixing factual alignment.

### Description
- Added/updated the file `_posts/2026-02-22-king-and-his-man-history.md` and adjusted frontmatter `title`, `date`, `categories`, `tags`, and `description` to reference the February 2026 release and Danjong-era context.  
- Rewrote the Korean briefing to frame the film against King Danjong’s deposition and its political aftermath (including 계유정난 and 사육신).  
- Replaced the glossary entries and updated the two quiz items (keeping answers hidden in `<details>`), and rewrote the English brief to match the Danjong-focused narrative.  
- Updated the reference list to point to Danjong-/계유정난-related sources (`encykorea`, `sillok`, `britannica`) for reader verification.

### Testing
- Ran `bundle exec jekyll build`, which failed due to a missing `jekyll` executable with the error `bundler: command not found: jekyll`.  
- Verified the updated post contents with `nl -ba _posts/2026-02-22-king-and-his-man-history.md` to inspect the inserted sections.  
- Confirmed the new post file is present in the working tree via `git status --short`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699afdd0f7848321aae2abdae5a64461)