### PR TITLE
Remove explicit middle-school phrasing from Artemis posts

### DIFF
--- a/_posts/2026-02-24-artemis-01-why-back-to-moon.md
+++ b/_posts/2026-02-24-artemis-01-why-back-to-moon.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "달 재방문, 숙제 검사 아닙니다 🌕 아르테미스가 다시 달로 가는 진짜 이유"
+date: 2026-02-24 09:00:00 +0900
+categories: [News, Global, Insight]
+tags: [artemis, moon, nasa]
+description: "쉽게 이해하는 아르테미스 프로젝트의 핵심 목표"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+“이미 달에 갔는데 왜 또 가요?”라는 질문, 정말 좋아요. 아르테미스 프로젝트는 옛날처럼 ‘한 번 착륙하고 끝’이 아니라, 달에서 오래 머무르는 기술을 연습하는 계획이에요. 이유는 간단합니다. 화성처럼 더 먼 곳으로 가려면, 먼저 가까운 달에서 생존 기술을 검증해야 하거든요. 예를 들어 우주비행사가 마실 물과 산소를 안정적으로 만들 수 있는지, 달의 극한 온도(낮엔 뜨겁고 밤엔 매우 추움)를 버틸 수 있는지, 지구와 통신이 끊기지 않는지 등을 확인해야 해요. 또 달 탐사는 과학 실험실 역할도 합니다. 달의 토양과 암석을 조사하면 태양계 초기에 무슨 일이 있었는지 힌트를 얻을 수 있어요. 한마디로 아르테미스는 “달 여행 이벤트”가 아니라 “미래 우주 이민 준비 수업”에 더 가깝습니다.
+
+## 🎓 용어 설명 (KR)
+
+- **아르테미스(Artemis)**: 미국 NASA가 중심이 되어 추진하는 유인 달 탐사 프로그램
+- **장기 체류(Long-duration stay)**: 며칠이 아니라 수주~수개월 동안 머무는 임무 개념
+- **전초기지(Outpost)**: 더 먼 탐사를 준비하기 위한 중간 거점
+
+## 🧠 퀴즈 (KR)
+
+Q. 아르테미스 프로젝트의 가장 중요한 목적에 가까운 것은?
+
+1) 달에서 기념사진 찍기  
+2) 화성 탐사를 위한 생존·기술 검증  
+3) 달 표면에 대형 광고 설치
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+Artemis is not just about landing on the Moon again. It is a long-term training program for deep-space missions. NASA and partners test life-support, communication, and survival systems on the Moon before aiming for Mars.
+
+## 🔗 참고 링크
+
+- NASA Artemis: https://www.nasa.gov/humans-in-space/artemis/
+- NASA Moon to Mars: https://www.nasa.gov/moon-to-mars/
+- ESA Moon Exploration: https://www.esa.int/Science_Exploration/Human_and_Robotic_Exploration/Exploration/Moon_exploration

--- a/_posts/2026-02-24-artemis-02-mission-steps.md
+++ b/_posts/2026-02-24-artemis-02-mission-steps.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "아르테미스는 시즌제였다? 🎬 1·2·3단계로 보는 달 귀환 로드맵"
+date: 2026-02-24 09:20:00 +0900
+categories: [News, Global, Insight]
+tags: [artemis1, artemis2, artemis3, nasa]
+description: "아르테미스 1·2·3 임무를 쉽게 이해하도록 정리"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+아르테미스 임무는 게임 튜토리얼처럼 단계적으로 진행됩니다. **아르테미스 1**은 사람이 타지 않은 시험 비행이었어요. 로켓, 우주선, 지구 귀환 시스템이 제대로 작동하는지 먼저 확인했죠. **아르테미스 2**는 우주비행사가 탑승하지만 달에 착륙하지 않고 달 주위를 도는 임무입니다. 쉽게 말해 “실전 전 리허설”이에요. 마지막으로 **아르테미스 3**에서는 실제로 우주비행사가 달에 착륙할 계획입니다. 이때 중요한 목표 중 하나가 달 남극 탐사예요. 왜 남극일까요? 물 얼음이 있을 가능성이 크기 때문입니다. 물은 마시는 용도뿐 아니라 산소와 연료 생산에도 도움이 될 수 있어요. 즉 아르테미스의 단계별 임무는 멋진 장면을 만들기 위한 순서가 아니라, 실패 가능성을 줄이기 위한 과학적인 안전 절차입니다.
+
+## 🎓 용어 설명 (KR)
+
+- **무인 시험 비행**: 사람이 타기 전에 기계 성능을 검증하는 임무
+- **유인 비행**: 우주비행사가 직접 탑승하는 임무
+- **달 남극(South Pole)**: 얼음 자원 탐사 후보지로 주목받는 지역
+
+## 🧠 퀴즈 (KR)
+
+Q. 아르테미스 2의 특징으로 맞는 것은?
+
+1) 달 착륙 임무다  
+2) 우주비행사가 탑승해 달 주변을 비행한다  
+3) 화성에 착륙한다
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+Artemis missions follow clear steps: Artemis I tested systems without crew, Artemis II sends astronauts around the Moon, and Artemis III aims for a lunar landing. This phased approach reduces risk and improves safety.
+
+## 🔗 참고 링크
+
+- NASA Artemis Missions: https://www.nasa.gov/humans-in-space/artemis-missions/
+- NASA Artemis I: https://www.nasa.gov/mission/artemis-i/
+- NASA Artemis II: https://www.nasa.gov/mission/artemis-ii/

--- a/_posts/2026-02-24-artemis-03-orion-spacecraft.md
+++ b/_posts/2026-02-24-artemis-03-orion-spacecraft.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "우주선 이름이 오리온? 🛰️ 아르테미스 승무원 택시의 모든 것"
+date: 2026-02-24 09:40:00 +0900
+categories: [News, Global, Insight]
+tags: [orion, artemis, spacecraft]
+description: "아르테미스에서 오리온 우주선이 하는 일을 쉽게 설명"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+아르테미스에서 우주비행사가 타는 핵심 우주선은 **오리온(Orion)**입니다. 오리온은 단순한 ‘캡슐’이 아니라, 승무원 생존을 위해 필요한 장비가 모인 작은 우주 집이에요. 내부에는 산소 공급, 온도 조절, 전력 관리, 통신 시스템이 들어가고, 긴 비행 동안 비상 상황을 견디도록 설계됩니다. 오리온의 또 다른 강점은 지구 재진입 능력이에요. 달에서 돌아올 때는 속도가 매우 빠르기 때문에, 열 차폐막이 엄청난 마찰열을 버텨야 합니다. 이 부분이 실패하면 귀환 자체가 위험해져요. 그래서 아르테미스 1에서 특히 재진입 성능을 꼼꼼히 확인했습니다. 쉽게 비유하면, 오리온은 “달까지 가는 버스”가 아니라 “우주에서 살아남게 해주는 생명유지 교실”이라고 이해하면 정확해요.
+
+## 🎓 용어 설명 (KR)
+
+- **재진입(Re-entry)**: 우주선이 대기권으로 다시 들어오는 과정
+- **열 차폐막(Heat Shield)**: 대기 마찰로 생기는 고열을 막는 보호층
+- **생명유지장치(Life Support)**: 산소·온도·습도 등을 조절해 탑승자를 보호하는 시스템
+
+## 🧠 퀴즈 (KR)
+
+Q. 오리온 우주선에서 특히 중요한 기술로 적절한 것은?
+
+1) 게임 스트리밍 성능  
+2) 대기권 재진입 시 열 차폐 기술  
+3) 바다 잠수 기능
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+Orion is the crew spacecraft for Artemis. It provides life support, navigation, and safe return to Earth. Its heat shield is critical because re-entry from lunar missions is much faster and hotter than low-Earth-orbit returns.
+
+## 🔗 참고 링크
+
+- NASA Orion Spacecraft: https://www.nasa.gov/exploration/systems/orion/
+- Lockheed Martin Orion overview: https://www.lockheedmartin.com/en-us/products/orion.html
+- NASA Artemis I Flight Test: https://www.nasa.gov/specials/artemis-i/

--- a/_posts/2026-02-24-artemis-04-sls-rocket.md
+++ b/_posts/2026-02-24-artemis-04-sls-rocket.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "SLS 로켓, 그냥 큰 불꽃이 아니다 🔥 달로 가는 초강력 엘리베이터"
+date: 2026-02-24 10:00:00 +0900
+categories: [News, Global, Insight]
+tags: [sls, rocket, artemis]
+description: "아르테미스의 발사체 SLS를 쉽게 설명"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+아르테미스 임무에서 오리온 우주선을 달 방향으로 보내는 거대한 발사체가 **SLS(Space Launch System)**예요. 왜 이렇게 큰 로켓이 필요할까요? 달까지 가려면 지구 저궤도보다 훨씬 많은 에너지가 필요하기 때문입니다. SLS는 강력한 엔진과 보조 로켓으로 초반 추력을 높여 무거운 화물과 승무원 우주선을 함께 실어 올립니다. 이때 발사는 단순히 “위로 쏘기”가 아니에요. 정확한 각도와 속도를 맞춰야 달 궤도로 효율적으로 진입할 수 있습니다. 만약 계산이 틀리면 연료를 낭비하거나 임무 전체가 지연될 수 있어요. 즉 SLS는 힘만 센 로켓이 아니라, 정밀한 물리 계산과 제어 기술의 결과물입니다. 여러분이 수학·과학에서 배우는 속력, 힘, 궤도 개념이 실제로 쓰이는 대표 사례죠.
+
+## 🎓 용어 설명 (KR)
+
+- **추력(Thrust)**: 로켓을 앞으로 밀어주는 힘
+- **저궤도(LEO)**: 지구에서 비교적 가까운 궤도 영역
+- **궤도 삽입(Orbital Injection)**: 목표 궤도에 정확히 들어가도록 속도·방향을 맞추는 과정
+
+## 🧠 퀴즈 (KR)
+
+Q. SLS가 필요한 핵심 이유는?
+
+1) 달까지 갈 만큼 충분한 에너지를 제공하기 위해  
+2) 로켓 소리를 더 크게 내기 위해  
+3) 우주선 색상을 바꾸기 위해
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 1번**
+
+</details>
+
+## 🌍 English Brief
+
+SLS is the heavy-lift rocket of Artemis. Lunar missions require much more energy than low-Earth orbit missions. SLS combines powerful thrust and precise guidance to send Orion toward the Moon.
+
+## 🔗 참고 링크
+
+- NASA SLS: https://www.nasa.gov/exploration/systems/sls/
+- NASA Artemis launch system overview: https://www.nasa.gov/humans-in-space/artemis/
+- NASA STEM Rocket Basics: https://www.nasa.gov/stem/

--- a/_posts/2026-02-24-artemis-05-gateway.md
+++ b/_posts/2026-02-24-artemis-05-gateway.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "달 궤도에 ‘우주 정거장 환승센터’ 만든다? 🛰️ 게이트웨이 쉽게 이해하기"
+date: 2026-02-24 10:20:00 +0900
+categories: [News, Global, Insight]
+tags: [gateway, lunar-orbit, artemis]
+description: "아르테미스 게이트웨이의 역할과 필요성을 쉽게 정리"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+아르테미스에는 달 표면만 중요한 게 아닙니다. 달 주변 궤도에 건설 중인 **게이트웨이(Gateway)**도 핵심이에요. 게이트웨이는 지구의 국제우주정거장(ISS)처럼 완전히 같은 기능은 아니지만, 달 임무를 준비하고 연결하는 ‘환승 기지’ 역할을 합니다. 우주비행사와 화물을 모듈 단위로 관리하고, 달 착륙선과 도킹해 임무를 이어갈 수 있어요. 왜 이렇게 복잡하게 하냐고요? 한 번에 모든 것을 해결하는 방식보다, 중간 거점을 두면 임무를 유연하게 조정하기 쉽기 때문입니다. 장기적으로는 화성 탐사 기술 실험에도 도움이 됩니다. 쉽게 보면 게이트웨이를 “달 근처의 미니 연구소 + 우주 교통 허브”로 생각하면 됩니다. 우주 탐사도 결국 네트워크와 협업이 중요하다는 사실을 보여주는 사례예요.
+
+## 🎓 용어 설명 (KR)
+
+- **게이트웨이(Gateway)**: 달 궤도에서 운영될 국제 협력 우주정거장 개념
+- **도킹(Docking)**: 두 우주선이 우주에서 정밀하게 결합하는 기술
+- **모듈(Module)**: 기능별로 나눠 제작한 우주정거장 구성 요소
+
+## 🧠 퀴즈 (KR)
+
+Q. 게이트웨이의 역할로 가장 알맞은 것은?
+
+1) 달 표면의 축구 경기장  
+2) 달 임무를 연결하는 궤도상의 중간 거점  
+3) 지구 대기 오염 정화 장치
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+Gateway is a lunar-orbit outpost for Artemis. It supports docking, logistics, and mission coordination around the Moon. Think of it as a transfer hub that can make future deep-space missions more flexible.
+
+## 🔗 참고 링크
+
+- NASA Gateway: https://www.nasa.gov/gateway/
+- ESA on Gateway: https://www.esa.int/Science_Exploration/Human_and_Robotic_Exploration/Gateway
+- CSA Lunar Gateway: https://www.asc-csa.gc.ca/eng/astronomy/moon-exploration/lunar-gateway.asp

--- a/_posts/2026-02-24-artemis-06-south-pole-ice.md
+++ b/_posts/2026-02-24-artemis-06-south-pole-ice.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "달 남극의 숨은 보물은 다이아가 아니라 물? 💧 얼음이 바꾸는 우주 탐사"
+date: 2026-02-24 10:40:00 +0900
+categories: [News, Global, Insight]
+tags: [lunar-south-pole, water-ice, isru]
+description: "달 남극 물 얼음이 왜 중요한지 쉽게 설명"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+아르테미스가 달 남극에 주목하는 가장 큰 이유는 **물 얼음** 가능성 때문입니다. 달의 일부 분화구는 햇빛이 거의 닿지 않아 매우 차갑고, 그곳에 얼음이 남아 있을 수 있어요. 물이 왜 중요할까요? 첫째, 우주비행사의 식수와 생활용수로 쓸 수 있습니다. 둘째, 물을 분해하면 산소와 수소를 얻을 수 있는데, 산소는 호흡에, 수소는 연료 기술에 활용 가능성이 있어요. 이렇게 현지 자원을 활용하면 지구에서 모든 물자를 실어 나르는 부담이 줄어듭니다. 이것을 **ISRU(현지 자원 활용)**라고 해요. 물론 실제 채굴과 정제는 쉬운 일이 아닙니다. 극저온 환경, 먼지 문제, 장비 고장 위험을 이겨내야 하죠. 그래도 성공하면 달 탐사는 ‘짧은 방문’에서 ‘지속 가능한 체류’로 바뀔 수 있습니다.
+
+## 🎓 용어 설명 (KR)
+
+- **물 얼음(Water Ice)**: 달 극지방 그늘 지역에 존재 가능성이 있는 자원
+- **ISRU**: 현지에서 얻은 자원을 임무에 직접 활용하는 기술
+- **지속 가능 탐사(Sustainable Exploration)**: 한 번이 아닌 반복·장기 운영이 가능한 탐사 방식
+
+## 🧠 퀴즈 (KR)
+
+Q. 달의 물 얼음이 중요한 가장 큰 이유는?
+
+1) 달 아이스크림을 만들 수 있어서  
+2) 물·산소·연료 관련 자원으로 활용 가능해서  
+3) 달 표면 색을 파랗게 바꿀 수 있어서
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+Lunar south-pole ice could support drinking water, oxygen production, and fuel-related processes. Using local resources (ISRU) can reduce mission cost and enable longer stays on the Moon.
+
+## 🔗 참고 링크
+
+- NASA on lunar water: https://www.nasa.gov/moon/
+- USGS Moon resources overview: https://www.usgs.gov/
+- Nature (space science): https://www.nature.com/subjects/moon

--- a/_posts/2026-02-24-artemis-07-spacesuits-safety.md
+++ b/_posts/2026-02-24-artemis-07-spacesuits-safety.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "우주복은 ‘멋’이 아니라 생명줄 🧑‍🚀 달에서 살아남는 슈트 과학"
+date: 2026-02-24 11:00:00 +0900
+categories: [News, Global, Insight]
+tags: [spacesuit, artemis, safety]
+description: "아르테미스 달 탐사에서 우주복과 안전 기술의 중요성"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+달은 지구처럼 공기가 없고, 온도 변화가 매우 큽니다. 그래서 우주복은 옷이 아니라 ‘개인용 우주선’에 가까워요. 아르테미스용 차세대 우주복은 움직임을 더 자유롭게 하면서도, 방사선·미세먼지·극한 온도에서 승무원을 보호해야 합니다. 특히 달 먼지는 매우 미세하고 날카로워 장비를 마모시키고 건강에도 영향을 줄 수 있어요. 따라서 헬멧 시야, 장갑의 조작감, 관절 유연성, 생명유지 시스템이 모두 중요합니다. 또 우주비행사는 비상상황 대응 훈련을 반복해요. 산소 압력 이상, 통신 오류, 장비 고장 같은 상황을 가정해 연습하는 거죠. 결국 달 탐사는 ‘용감함’만으로 되는 일이 아니라, 수많은 안전 기준과 반복 훈련 위에서 이루어지는 고도의 팀 프로젝트입니다.
+
+## 🎓 용어 설명 (KR)
+
+- **미세운석(Micrometeoroid)**: 우주 공간을 빠르게 이동하는 아주 작은 입자
+- **생명유지시스템(PLSS)**: 산소 공급, 온도 조절 등을 담당하는 우주복 핵심 장치
+- **달 레골리스(Regolith)**: 달 표면을 덮고 있는 미세한 흙·먼지 층
+
+## 🧠 퀴즈 (KR)
+
+Q. 아르테미스 우주복에서 중요한 요소가 아닌 것은?
+
+1) 온도·산소 관리  
+2) 관절 움직임과 방진 성능  
+3) SNS 라이브 방송 기능
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 3번**
+
+</details>
+
+## 🌍 English Brief
+
+A lunar spacesuit is a survival system, not just clothing. Artemis suits must protect astronauts from extreme temperatures, dust, and radiation while allowing flexible movement for science work.
+
+## 🔗 참고 링크
+
+- NASA xEMU / Artemis suits: https://www.nasa.gov/humans-in-space/spacesuits/
+- Axiom Space suits for Artemis: https://www.axiomspace.com/
+- NASA Human Exploration: https://www.nasa.gov/humans-in-space/

--- a/_posts/2026-02-24-artemis-08-moon-science.md
+++ b/_posts/2026-02-24-artemis-08-moon-science.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "달은 돌멩이만 있는 줄 알았지? 🔬 아르테미스 과학 실험이 중요한 이유"
+date: 2026-02-24 11:20:00 +0900
+categories: [News, Global, Insight]
+tags: [moon-science, artemis, experiment]
+description: "아르테미스가 달에서 어떤 과학 실험을 하는지 쉽게 설명"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+아르테미스의 목표는 ‘착륙 성공’ 자체가 끝이 아닙니다. 진짜 핵심은 달에서 어떤 데이터를 얻느냐예요. 과학자들은 달 암석과 토양을 분석해 태양계 초기에 일어난 충돌과 지질 변화를 추적합니다. 또 달 환경에서 인체가 어떻게 반응하는지, 장비가 얼마나 오래 버티는지도 중요한 연구 주제예요. 예를 들어 방사선 노출량, 미세먼지 영향, 장기 체류 시 심리·생리 변화 등을 측정하면 화성 탐사 준비에 큰 도움이 됩니다. 달은 지구보다 조건이 훨씬 가혹해서, 여기서 통과한 기술은 지구의 재난 대응·원격 로봇·의료 모니터링에도 응용될 수 있어요. 즉 달 과학은 우주 이야기로 끝나지 않고, 결국 우리 생활 기술 발전으로 연결됩니다.
+
+## 🎓 용어 설명 (KR)
+
+- **지질 샘플(Geological Sample)**: 암석·토양처럼 연구를 위해 수집한 물질
+- **방사선(Radiation)**: 우주 환경에서 생명체와 장비에 영향을 주는 에너지
+- **기술 파생효과(Spinoff)**: 우주 기술이 지상 산업으로 확장되는 현상
+
+## 🧠 퀴즈 (KR)
+
+Q. 달 과학 실험이 중요한 이유로 가장 적절한 것은?
+
+1) 우주복 색상 테스트만 하기 위해  
+2) 태양계 역사 연구와 미래 탐사 기술 검증을 위해  
+3) 달에서만 사용하는 화폐를 만들기 위해
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+Artemis science focuses on samples, radiation, and long-duration operations. Lunar research helps us understand Solar System history and develop technologies that can support future Mars missions and Earth applications.
+
+## 🔗 참고 링크
+
+- NASA Science - Moon: https://science.nasa.gov/moon/
+- Lunar and Planetary Institute: https://www.lpi.usra.edu/
+- NASA Spinoff: https://spinoff.nasa.gov/

--- a/_posts/2026-02-24-artemis-09-international-team.md
+++ b/_posts/2026-02-24-artemis-09-international-team.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "미국 혼자 가는 줄 알았죠? 🤝 아르테미스는 국제 팀플 프로젝트"
+date: 2026-02-24 11:40:00 +0900
+categories: [News, Global, Insight]
+tags: [artemis-accords, international, space-policy]
+description: "아르테미스 국제 협력 구조와 아르테미스 협정 소개"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+아르테미스는 미국 NASA가 중심이지만, 실제로는 여러 나라와 기업이 참여하는 국제 협력 프로젝트입니다. 유럽우주국(ESA), 일본(JAXA), 캐나다(CSA) 등 다양한 파트너가 우주선 부품, 로봇팔, 과학 장비, 운영 기술을 함께 개발하고 있어요. 이런 협력에는 기술만큼 규칙도 중요합니다. 그래서 등장한 것이 **아르테미스 협정(Artemis Accords)**이에요. 이 협정은 우주 활동에서 안전 구역, 데이터 공개, 평화적 이용 같은 원칙을 제시합니다. 쉽게 말해 “우주에서도 룰을 지키며 같이 하자”는 약속이죠. 쉽게 비유하면, 축구 경기에서 규칙이 있어야 공정하게 플레이할 수 있는 것과 비슷합니다. 미래 우주 시대는 과학 실력뿐 아니라 국제 협업 능력도 필수라는 점을 아르테미스가 보여주고 있습니다.
+
+## 🎓 용어 설명 (KR)
+
+- **아르테미스 협정**: 평화적·투명한 우주 탐사를 위한 국제 원칙 모음
+- **국제 협력(International Cooperation)**: 여러 국가가 역할을 나눠 공동 목표를 수행하는 방식
+- **우주 거버넌스(Space Governance)**: 우주 활동의 규범·제도·운영 체계
+
+## 🧠 퀴즈 (KR)
+
+Q. 아르테미스 협정의 목적에 가장 가까운 것은?
+
+1) 우주 자원 독점 선언  
+2) 우주 탐사에서 지켜야 할 공통 원칙 제시  
+3) 로켓 디자인 통일 강제
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+Artemis is an international effort. The Artemis Accords provide principles for peaceful, transparent, and cooperative exploration. In short, space exploration needs both technology and shared rules.
+
+## 🔗 참고 링크
+
+- NASA Artemis Accords: https://www.nasa.gov/artemis-accords/
+- U.S. Department of State Artemis Accords: https://www.state.gov/artemis-accords/
+- UNOOSA (space law/resources): https://www.unoosa.org/

--- a/_posts/2026-02-24-artemis-10-jobs-and-future.md
+++ b/_posts/2026-02-24-artemis-10-jobs-and-future.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title: "우주인은 한 명, 직업은 수천 개 🚀 아르테미스가 만드는 미래 진로 지도"
+date: 2026-02-24 12:00:00 +0900
+categories: [News, Global, Insight]
+tags: [stem, career, artemis]
+description: "아르테미스 프로젝트가 학생들의 미래 직업에 주는 힌트"
+---
+
+## 🗞️ 오늘의 핵심 브리핑 (KR)
+
+아르테미스를 보면 많은 학생이 “나도 우주비행사가 될까?”를 떠올립니다. 물론 멋진 꿈이에요. 그런데 실제 우주 프로젝트는 우주비행사만으로 움직이지 않습니다. 로켓 엔지니어, 소프트웨어 개발자, 데이터 과학자, 재료공학자, 의사, 심리학자, 통신 전문가, 디자이너까지 다양한 직업이 함께 일해요. 예를 들어 우주복 관절 설계에는 기계공학이, 장거리 통신에는 전자·컴퓨터공학이, 우주인의 건강 관리는 의학·생명과학이 필요합니다. 즉 학교에서 배우는 수학·과학·영어·협업 능력이 모두 연결됩니다. 아르테미스는 “특별한 천재만 가는 세계”가 아니라, 서로 다른 재능이 팀으로 합쳐지는 프로젝트라는 점에서 의미가 큽니다. 미래 진로를 고민할 때 가장 좋은 메시지는 이것입니다: 좋아하는 과목 하나를 깊게 파고, 다른 친구와 협력하는 힘을 키우면 우주 시대의 주인공이 될 수 있다.
+
+## 🎓 용어 설명 (KR)
+
+- **STEM**: 과학(Science), 기술(Technology), 공학(Engineering), 수학(Mathematics)
+- **다학제(Multidisciplinary)**: 여러 학문 분야가 함께 문제를 해결하는 방식
+- **시스템 엔지니어링**: 복잡한 기술 요소를 통합해 전체 성능을 관리하는 분야
+
+## 🧠 퀴즈 (KR)
+
+Q. 아르테미스 프로젝트에 대한 설명으로 옳은 것은?
+
+1) 우주비행사만 있으면 된다  
+2) 다양한 직업과 전공이 협력해야 성공할 수 있다  
+3) 체육 성적만 높으면 참여 가능하다
+
+<details>
+  <summary>정답 보기</summary>
+
+  **정답: 2번**
+
+</details>
+
+## 🌍 English Brief
+
+Artemis creates opportunities beyond astronauts. Engineers, coders, doctors, scientists, and designers all contribute. For students, strong basics in STEM and teamwork are key skills for the space era.
+
+## 🔗 참고 링크
+
+- NASA STEM: https://www.nasa.gov/stem/
+- ESA Education: https://www.esa.int/Education
+- Smithsonian Air and Space (education): https://airandspace.si.edu/learn


### PR DESCRIPTION
### Motivation

- Make the Artemis series tone-friendly without explicitly labeling the audience as "middle-school" by removing direct references and simplifying phrasing.
- Preserve the original intent: approachable, educational posts that remain classroom- and family-friendly while avoiding audience labels.

### Description

- Updated eight markdown posts under `_posts/` to remove or rephrase explicit middle-school audience phrases and similar expressions while keeping the same easy-to-understand tone. 
- Files modified: `_posts/2026-02-24-artemis-01-why-back-to-moon.md`, `_posts/2026-02-24-artemis-02-mission-steps.md`, `_posts/2026-02-24-artemis-03-orion-spacecraft.md`, `_posts/2026-02-24-artemis-04-sls-rocket.md`, `_posts/2026-02-24-artemis-05-gateway.md`, `_posts/2026-02-24-artemis-06-south-pole-ice.md`, `_posts/2026-02-24-artemis-09-international-team.md`, and `_posts/2026-02-24-artemis-10-jobs-and-future.md`. 
- Preserved each post's structure and educational elements (Korean briefing, glossary, hidden-answer quiz, English brief, and reference links) and only altered wording to remove explicit audience labels.

### Testing

- Ran a repository-wide search to confirm no remaining occurrences of the phrases `중학생`, `학생 입장`, or `중학생 관점`, and found none. 
- Verified the expected eight files were updated in the repository and that the changes were saved. 
- Reviewed the top-level content of each modified file to confirm the intended wording changes and that the posts render as structured markdown files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d28f4c63083218fcd1ae533f2f90f)