### PR TITLE
Add standalone Quiz SPA with AES-encrypted data support and wrong-answer notebook

### DIFF
--- a/_tabs/quiz.md
+++ b/_tabs/quiz.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Quiz
+icon: fas fa-gamepad
+order: 5
+---
+
+퀴즈 앱을 실행하려면 아래 버튼을 눌러주세요.
+
+<a href="/quiz/" class="btn btn-primary">퀴즈 앱 열기</a>

--- a/quiz/app.js
+++ b/quiz/app.js
@@ -1,0 +1,305 @@
+const state = {
+  quizData: [],
+  currentIndex: 0,
+  score: 0,
+  answers: [],
+  encryptedPayload: null,
+};
+
+const wrongNoteKey = 'quizWrongAnswers';
+
+const $ = (id) => document.getElementById(id);
+
+const dataUrlInput = $('dataUrl');
+const loadBtn = $('loadBtn');
+const sampleBtn = $('sampleBtn');
+const statusEl = $('status');
+const quizPanel = $('quizPanel');
+const questionArea = $('questionArea');
+const submitBtn = $('submitBtn');
+const nextBtn = $('nextBtn');
+const feedbackEl = $('feedback');
+const progressText = $('progressText');
+const scoreText = $('scoreText');
+const progressFill = $('progressFill');
+const resultPanel = $('resultPanel');
+const resultSummary = $('resultSummary');
+const explanations = $('explanations');
+const restartBtn = $('restartBtn');
+const wrongList = $('wrongList');
+const clearWrongBtn = $('clearWrongBtn');
+const passwordModal = $('passwordModal');
+const passwordInput = $('passwordInput');
+const decryptBtn = $('decryptBtn');
+const passwordError = $('passwordError');
+
+function setStatus(message, isError = false) {
+  statusEl.textContent = message;
+  statusEl.style.color = isError ? 'var(--danger)' : 'var(--muted)';
+}
+
+function resetQuizState() {
+  state.currentIndex = 0;
+  state.score = 0;
+  state.answers = [];
+  feedbackEl.textContent = '';
+  feedbackEl.className = 'feedback';
+  nextBtn.classList.add('hidden');
+  submitBtn.disabled = false;
+  resultPanel.classList.add('hidden');
+}
+
+function parseQuizPayload(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (payload && Array.isArray(payload.questions)) return payload.questions;
+  throw new Error('퀴즈 데이터 형식이 올바르지 않습니다. 배열 또는 { questions: [] }가 필요합니다.');
+}
+
+async function fetchQuizData(url) {
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`데이터 요청 실패 (${res.status})`);
+  return res.text();
+}
+
+function parseEncryptedContent(text) {
+  const raw = text.replace(/^ENC_v1\s*/, '').trim();
+
+  try {
+    const asJson = JSON.parse(raw);
+    if (asJson.iv && asJson.data) {
+      return { iv: asJson.iv, data: asJson.data, encoding: asJson.encoding || 'base64' };
+    }
+  } catch {
+    // Ignore and try delimiter parsing.
+  }
+
+  const parts = raw.split(':');
+  if (parts.length < 2) throw new Error('암호화 데이터 형식이 잘못되었습니다.');
+  return { iv: parts[0], data: parts.slice(1).join(':'), encoding: 'base64' };
+}
+
+function decryptAes256Cbc(payload, password) {
+  const key = CryptoJS.SHA256(password);
+  const iv = CryptoJS.enc.Base64.parse(payload.iv);
+  const ciphertext = CryptoJS.enc.Base64.parse(payload.data);
+
+  const decrypted = CryptoJS.AES.decrypt(
+    { ciphertext },
+    key,
+    {
+      iv,
+      mode: CryptoJS.mode.CBC,
+      padding: CryptoJS.pad.Pkcs7,
+    },
+  );
+
+  const plaintext = decrypted.toString(CryptoJS.enc.Utf8);
+  if (!plaintext) throw new Error('복호화에 실패했습니다. 비밀번호를 확인해 주세요.');
+  return plaintext;
+}
+
+function renderQuestion() {
+  const q = state.quizData[state.currentIndex];
+  if (!q) return;
+
+  progressText.textContent = `${state.currentIndex + 1} / ${state.quizData.length}`;
+  scoreText.textContent = `점수: ${state.score}`;
+  progressFill.style.width = `${((state.currentIndex) / state.quizData.length) * 100}%`;
+
+  const imageHtml = q.image_url ? `<img src="${q.image_url}" alt="문항 이미지" class="question-image"/>` : '';
+  let inputHtml = '';
+
+  if (q.type === 'short') {
+    inputHtml = `<input id="shortAnswer" type="text" placeholder="정답을 입력하세요" autocomplete="off" />`;
+  } else {
+    const choices = (q.choices || []).map((choice, idx) => `
+      <label class="choice">
+        <input type="radio" name="choice" value="${idx}" />
+        <span>${choice}</span>
+      </label>
+    `).join('');
+    inputHtml = `<div class="choices">${choices}</div>`;
+  }
+
+  questionArea.innerHTML = `
+    ${imageHtml}
+    <h3 class="question-title">Q${state.currentIndex + 1}. ${q.question}</h3>
+    ${inputHtml}
+  `;
+
+  feedbackEl.textContent = '';
+  feedbackEl.className = 'feedback';
+  submitBtn.disabled = false;
+  nextBtn.classList.add('hidden');
+}
+
+function normalizeAnswer(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function getUserAnswer(question) {
+  if (question.type === 'short') {
+    return $('shortAnswer')?.value ?? '';
+  }
+
+  const checked = document.querySelector('input[name="choice"]:checked');
+  if (!checked) return null;
+  return Number(checked.value);
+}
+
+function saveWrongNote(entry) {
+  const oldData = JSON.parse(localStorage.getItem(wrongNoteKey) || '[]');
+  oldData.push({ ...entry, ts: new Date().toISOString() });
+  localStorage.setItem(wrongNoteKey, JSON.stringify(oldData.slice(-100)));
+  renderWrongNotes();
+}
+
+function renderWrongNotes() {
+  const list = JSON.parse(localStorage.getItem(wrongNoteKey) || '[]');
+  if (!list.length) {
+    wrongList.innerHTML = '<li>오답 노트가 비어 있습니다.</li>';
+    return;
+  }
+
+  wrongList.innerHTML = list.slice().reverse().map((item) => {
+    return `<li><strong>${item.question}</strong><br/>내 답: ${item.userAnswer} / 정답: ${item.correctAnswer}</li>`;
+  }).join('');
+}
+
+function evaluateCurrentQuestion() {
+  const q = state.quizData[state.currentIndex];
+  const userAnswer = getUserAnswer(q);
+
+  if (userAnswer === null || normalizeAnswer(userAnswer) === '') {
+    feedbackEl.textContent = '답안을 입력/선택해 주세요.';
+    feedbackEl.className = 'feedback fail';
+    return;
+  }
+
+  const correctAnswer = q.answer;
+  const isCorrect = q.type === 'short'
+    ? normalizeAnswer(userAnswer) === normalizeAnswer(correctAnswer)
+    : Number(userAnswer) === Number(correctAnswer);
+
+  if (isCorrect) {
+    state.score += 1;
+    feedbackEl.textContent = '정답입니다!';
+    feedbackEl.className = 'feedback success';
+  } else {
+    feedbackEl.textContent = `오답입니다. 정답: ${Array.isArray(q.choices) ? q.choices[correctAnswer] : correctAnswer}`;
+    feedbackEl.className = 'feedback fail';
+    saveWrongNote({
+      question: q.question,
+      userAnswer: Array.isArray(q.choices) ? q.choices[userAnswer] ?? userAnswer : userAnswer,
+      correctAnswer: Array.isArray(q.choices) ? q.choices[correctAnswer] : correctAnswer,
+    });
+  }
+
+  state.answers.push({ ...q, userAnswer, isCorrect });
+  submitBtn.disabled = true;
+  nextBtn.classList.remove('hidden');
+  scoreText.textContent = `점수: ${state.score}`;
+  progressFill.style.width = `${((state.currentIndex + 1) / state.quizData.length) * 100}%`;
+}
+
+function showResult() {
+  quizPanel.classList.add('hidden');
+  resultPanel.classList.remove('hidden');
+
+  resultSummary.textContent = `${state.quizData.length}문제 중 ${state.score}문제 정답 (${Math.round((state.score / state.quizData.length) * 100)}점)`;
+
+  explanations.innerHTML = state.answers.map((item, i) => {
+    const answerText = Array.isArray(item.choices) ? item.choices[item.answer] : item.answer;
+    return `
+      <div class="explanation-item">
+        <p><strong>Q${i + 1}. ${item.question}</strong></p>
+        <p>내 답: ${Array.isArray(item.choices) ? (item.choices[item.userAnswer] ?? item.userAnswer) : item.userAnswer}</p>
+        <p>정답: ${answerText}</p>
+        <p>해설: ${item.explanation || '해설 없음'}</p>
+      </div>
+    `;
+  }).join('');
+}
+
+const sampleQuizUrl = './sample-quiz.json';
+
+async function loadFlow(customUrl) {
+  const url = (customUrl || dataUrlInput.value).trim();
+  if (!url) {
+    setStatus('데이터 URL을 입력해 주세요.', true);
+    return;
+  }
+
+  setStatus('데이터를 불러오는 중...');
+
+  try {
+    const text = await fetchQuizData(url);
+
+    if (text.startsWith('ENC_v1')) {
+      state.encryptedPayload = parseEncryptedContent(text);
+      passwordModal.classList.remove('hidden');
+      passwordError.textContent = '';
+      passwordInput.value = '';
+      setStatus('암호화된 파일을 감지했습니다. 비밀번호를 입력하세요.');
+      return;
+    }
+
+    const parsed = JSON.parse(text);
+    state.quizData = parseQuizPayload(parsed);
+    resetQuizState();
+    quizPanel.classList.remove('hidden');
+    renderQuestion();
+    setStatus(`총 ${state.quizData.length}문제를 로드했습니다.`);
+  } catch (err) {
+    console.error(err);
+    setStatus(err.message || '로드 중 오류가 발생했습니다.', true);
+  }
+}
+
+function decryptFlow() {
+  const password = passwordInput.value;
+
+  if (!password) {
+    passwordError.textContent = '비밀번호를 입력해 주세요.';
+    return;
+  }
+
+  try {
+    const plaintext = decryptAes256Cbc(state.encryptedPayload, password);
+    const parsed = JSON.parse(plaintext);
+    state.quizData = parseQuizPayload(parsed);
+
+    resetQuizState();
+    passwordModal.classList.add('hidden');
+    quizPanel.classList.remove('hidden');
+    renderQuestion();
+    setStatus(`복호화 성공: 총 ${state.quizData.length}문제를 로드했습니다.`);
+  } catch (err) {
+    passwordError.textContent = err.message || '복호화 실패';
+  }
+}
+
+loadBtn.addEventListener('click', () => loadFlow());
+sampleBtn.addEventListener('click', () => loadFlow(sampleQuizUrl));
+submitBtn.addEventListener('click', evaluateCurrentQuestion);
+nextBtn.addEventListener('click', () => {
+  state.currentIndex += 1;
+  if (state.currentIndex >= state.quizData.length) {
+    showResult();
+    return;
+  }
+  renderQuestion();
+});
+restartBtn.addEventListener('click', () => {
+  resetQuizState();
+  quizPanel.classList.remove('hidden');
+  resultPanel.classList.add('hidden');
+  renderQuestion();
+});
+decryptBtn.addEventListener('click', decryptFlow);
+clearWrongBtn.addEventListener('click', () => {
+  localStorage.removeItem(wrongNoteKey);
+  renderWrongNotes();
+});
+
+renderWrongNotes();

--- a/quiz/index.html
+++ b/quiz/index.html
@@ -1,0 +1,81 @@
+---
+layout: null
+---
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quiz App</title>
+  <link rel="stylesheet" href="./style.css" />
+  <script defer src="https://cdn.jsdelivr.net/npm/crypto-js@4.2.0/crypto-js.min.js"></script>
+  <script defer src="./app.js"></script>
+</head>
+<body>
+  <main class="app">
+    <header class="app__header">
+      <h1>📘 퀴즈 앱</h1>
+      <p class="subtitle">GitHub Raw 데이터 기반 독립형 SPA</p>
+    </header>
+
+    <section class="card controls">
+      <h2>퀴즈 시작</h2>
+      <p class="subtitle">샘플 퀴즈로 바로 시작하거나 외부 Raw URL로 로드할 수 있습니다.</p>
+      <div class="actions top-actions">
+        <button id="sampleBtn">샘플 퀴즈(10문항) 시작</button>
+      </div>
+
+      <label for="dataUrl">외부 퀴즈 데이터 URL (Raw JSON/ENC)</label>
+      <input id="dataUrl" type="url" placeholder="https://raw.githubusercontent.com/.../quiz-data.json" />
+      <button id="loadBtn">외부 URL로 불러오기</button>
+      <p id="status" class="status" aria-live="polite"></p>
+    </section>
+
+    <section id="quizPanel" class="card hidden" aria-live="polite">
+      <div class="progress-wrap">
+        <div class="progress-meta">
+          <span id="progressText">0 / 0</span>
+          <span id="scoreText">점수: 0</span>
+        </div>
+        <div class="progress-bar">
+          <div id="progressFill" class="progress-fill"></div>
+        </div>
+      </div>
+
+      <article id="questionArea"></article>
+      <div class="actions">
+        <button id="submitBtn">정답 제출</button>
+        <button id="nextBtn" class="hidden">다음 문제</button>
+      </div>
+      <p id="feedback" class="feedback"></p>
+    </section>
+
+    <section id="resultPanel" class="card hidden">
+      <h2>결과</h2>
+      <p id="resultSummary"></p>
+      <div id="explanations" class="explanations"></div>
+      <button id="restartBtn">다시 풀기</button>
+    </section>
+
+    <section class="card wrong-note">
+      <div class="section-title-wrap">
+        <h2>📝 오답 노트</h2>
+        <button id="clearWrongBtn" class="btn-ghost">초기화</button>
+      </div>
+      <ul id="wrongList"></ul>
+    </section>
+  </main>
+
+  <div id="passwordModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="pwTitle">
+    <div class="modal-content">
+      <h2 id="pwTitle">암호화된 데이터</h2>
+      <p>비밀번호를 입력하세요.</p>
+      <input id="passwordInput" type="password" placeholder="비밀번호" />
+      <p id="passwordError" class="error"></p>
+      <div class="actions modal-actions">
+        <button id="decryptBtn">복호화</button>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/quiz/sample-quiz.json
+++ b/quiz/sample-quiz.json
@@ -1,0 +1,72 @@
+{
+  "title": "샘플 일반상식 퀴즈",
+  "questions": [
+    {
+      "type": "multiple",
+      "question": "대한민국의 수도는 어디인가요?",
+      "choices": ["부산", "서울", "인천", "대전"],
+      "answer": 1,
+      "explanation": "대한민국의 수도는 서울입니다."
+    },
+    {
+      "type": "multiple",
+      "question": "지구의 위성 이름은 무엇인가요?",
+      "choices": ["태양", "화성", "달", "금성"],
+      "answer": 2,
+      "explanation": "지구의 자연 위성은 달입니다."
+    },
+    {
+      "type": "short",
+      "question": "파이썬에서 리스트 길이를 구하는 내장 함수 이름은?",
+      "answer": "len",
+      "explanation": "len() 함수로 시퀀스 길이를 구합니다."
+    },
+    {
+      "type": "multiple",
+      "question": "HTTP 상태 코드 404는 무엇을 의미하나요?",
+      "choices": ["요청 성공", "권한 없음", "서버 오류", "리소스를 찾을 수 없음"],
+      "answer": 3,
+      "explanation": "404 Not Found는 요청한 리소스가 없음을 의미합니다."
+    },
+    {
+      "type": "multiple",
+      "question": "다음 중 CSS에서 글자 색상을 지정하는 속성은?",
+      "choices": ["font-size", "color", "background", "border"],
+      "answer": 1,
+      "explanation": "텍스트 색상은 color 속성으로 지정합니다."
+    },
+    {
+      "type": "short",
+      "question": "대한민국의 국기 이름은?",
+      "answer": "태극기",
+      "explanation": "대한민국 국기의 공식 명칭은 태극기입니다."
+    },
+    {
+      "type": "multiple",
+      "question": "다음 중 JavaScript의 배열 메서드가 아닌 것은?",
+      "choices": ["map", "filter", "reduce", "compile"],
+      "answer": 3,
+      "explanation": "compile은 일반적인 배열 메서드가 아닙니다."
+    },
+    {
+      "type": "multiple",
+      "question": "GitHub Pages 기본 사용자 사이트 주소 형태는?",
+      "choices": ["username.github.com", "username.github.io", "github.io/username", "pages.github/username"],
+      "answer": 1,
+      "explanation": "사용자 사이트는 보통 username.github.io 형태입니다."
+    },
+    {
+      "type": "short",
+      "question": "1킬로미터는 몇 미터인가요? 숫자만 입력",
+      "answer": "1000",
+      "explanation": "1km = 1000m 입니다."
+    },
+    {
+      "type": "multiple",
+      "question": "브라우저에서 로컬 저장소 키-값 저장에 사용하는 API는?",
+      "choices": ["sessionCookie", "indexedStore", "localStorage", "cacheValue"],
+      "answer": 2,
+      "explanation": "Web Storage API의 localStorage를 사용합니다."
+    }
+  ]
+}

--- a/quiz/style.css
+++ b/quiz/style.css
@@ -1,0 +1,175 @@
+:root {
+  --bg: #f4f6fb;
+  --card: #ffffff;
+  --text: #172033;
+  --muted: #637089;
+  --primary: #375dfb;
+  --primary-soft: #e9eeff;
+  --success: #138a42;
+  --danger: #c92a2a;
+  --border: #dce3f1;
+  --radius: 14px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans KR", sans-serif;
+  background: linear-gradient(180deg, #eef2ff, var(--bg));
+  color: var(--text);
+}
+
+.app {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 20px 14px 32px;
+}
+
+.app__header {
+  margin-bottom: 14px;
+}
+
+h1, h2, h3, p { margin: 0; }
+.subtitle { color: var(--muted); margin-top: 6px; }
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  margin: 12px 0;
+  box-shadow: 0 8px 20px rgba(31, 50, 90, 0.06);
+}
+
+label { display: block; font-weight: 600; margin-bottom: 8px; }
+input[type="url"],
+input[type="password"],
+input[type="text"] {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 15px;
+  margin-bottom: 10px;
+}
+
+button {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 14px;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+
+.status { margin-top: 8px; color: var(--muted); min-height: 18px; }
+
+.controls h2 { margin-bottom: 8px; }
+.top-actions { margin: 12px 0 14px; }
+
+.progress-wrap { margin-bottom: 16px; }
+.progress-meta {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  margin-bottom: 8px;
+  font-size: 14px;
+}
+.progress-bar {
+  width: 100%;
+  height: 10px;
+  background: #edf1f8;
+  border-radius: 999px;
+  overflow: hidden;
+}
+.progress-fill {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #4f77ff, #2b59ff);
+  transition: width 0.25s ease;
+}
+
+.question-image {
+  width: 100%;
+  border-radius: 10px;
+  margin: 10px 0;
+}
+
+.question-title { font-size: 1.08rem; font-weight: 700; margin-bottom: 10px; }
+.choices { display: grid; gap: 8px; margin-bottom: 12px; }
+.choice {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.feedback { margin-top: 10px; min-height: 20px; font-weight: 600; }
+.feedback.success { color: var(--success); }
+.feedback.fail { color: var(--danger); }
+
+.explanations { margin-top: 12px; display: grid; gap: 10px; }
+.explanation-item { border-top: 1px dashed var(--border); padding-top: 10px; }
+
+.section-title-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+#wrongList {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.42);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px;
+}
+.modal-content {
+  background: #fff;
+  width: min(420px, 100%);
+  border-radius: 12px;
+  padding: 16px;
+}
+.modal-actions { margin-top: 8px; }
+.error { color: var(--danger); min-height: 18px; }
+
+.hidden { display: none !important; }
+
+@media (max-width: 480px) {
+  .app { padding: 14px 10px 24px; }
+  .card { padding: 14px; }
+  button { width: 100%; }
+  .actions button { flex: 1 1 100%; }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, standalone quiz SPA that can load quiz data from a local sample or an external raw JSON/ENC payload and run in-page without backend changes.
- Support encrypted quiz payloads using an `ENC_v1` envelope and AES-256-CBC decryption to allow protected quiz distribution.
- Persist wrong answers locally so users can review mistakes across sessions.

### Description
- Added a new tab entry `_tabs/quiz.md` and a self-contained SPA under `quiz/` including `index.html`, `app.js`, `style.css`, and a `sample-quiz.json` sample dataset.
- Implemented quiz core in `app.js` with support for `multiple` and `short` question types, progress/score tracking, result explanations, and localStorage-backed wrong-answer notebook (`quizWrongAnswers`).
- Added encrypted payload handling via `ENC_v1` parsing and `decryptAes256Cbc` using `CryptoJS` (loaded from CDN) to decrypt `{ iv, data }` base64 blobs with a password modal flow.
- UI and styles provided in `style.css`; `index.html` wires assets and exposes controls for loading a sample quiz or fetching an external Raw JSON/ENC URL.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a42e0ba22083219a78556d6b07d8de)