### PR TITLE
Remove inaccurate post view counter integration

### DIFF
--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -1,6 +1,5 @@
 <script defer src="/assets/js/post-view-counter.js"></script>
 
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9677120965646002" crossorigin="anonymous"></script>
-<script async src="//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js"></script>
 
 <meta name="google-adsense-account" content="ca-pub-9677120965646002">

--- a/assets/js/post-view-counter.js
+++ b/assets/js/post-view-counter.js
@@ -14,76 +14,7 @@
     });
   }
 
-  function isPostDetailPage() {
-    var ogType = document.querySelector('meta[property="og:type"]');
-    var isArticle = ogType && ogType.getAttribute('content') === 'article';
-    var hasArticleContent = Boolean(document.querySelector('article .content'));
-
-    return Boolean(isArticle && hasArticleContent);
-  }
-
-  function findCounterMountPoint() {
-    var selectors = [
-      'article header .post-meta',
-      'article .post-meta.text-muted',
-      'article .post-meta',
-      '.post-meta.text-muted',
-      '.post-meta',
-      'article header',
-      'article .content',
-      'article'
-    ];
-
-    for (var i = 0; i < selectors.length; i += 1) {
-      var node = document.querySelector(selectors[i]);
-      if (node) return node;
-    }
-
-    return null;
-  }
-
-  function mountCounter() {
-    if (document.getElementById('post_view_counter')) return;
-
-    var mountPoint = findCounterMountPoint();
-    if (!mountPoint) return;
-
-    var counter = document.createElement('span');
-    counter.id = 'post_view_counter';
-    counter.className = 'post-view-counter';
-    counter.innerHTML = '👁 조회수 <span id="busuanzi_value_page_pv">-</span>';
-
-    if (mountPoint.classList.contains('post-meta')) {
-      mountPoint.appendChild(document.createTextNode(' · '));
-      mountPoint.appendChild(counter);
-    } else {
-      counter.style.display = 'inline-block';
-      counter.style.marginTop = '0.5rem';
-      counter.style.color = 'var(--text-muted-color, #6c757d)';
-      mountPoint.insertBefore(counter, mountPoint.firstChild);
-    }
-  }
-
-  function loadBusuanzi() {
-    if (document.querySelector('script[data-busuanzi]')) return;
-
-    var script = document.createElement('script');
-    script.async = true;
-    script.src = 'https://busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js';
-    script.setAttribute('data-busuanzi', 'true');
-    script.onload = function () {
-      if (window.BUSUANZI && typeof window.BUSUANZI.fetch === 'function') {
-        window.BUSUANZI.fetch();
-      }
-    };
-
-    document.body.appendChild(script);
-  }
-
   document.addEventListener('DOMContentLoaded', function () {
     initToc();
-    if (!isPostDetailPage()) return;
-    mountCounter();
-    loadBusuanzi();
   });
 })();


### PR DESCRIPTION
### Motivation

- The site displayed a page view counter using an external Busuanzi script that produced inaccurate metrics and should be removed.
- The objective is to stop injecting the external view-count script and remove the on-page counter insertion while preserving existing TOC behavior.

### Description

- Removed the Busuanzi script tag from `_includes/metadata-hook.html` so the external page-view loader is no longer injected.
- Removed the view-counter mounting and Busuanzi loader code from `assets/js/post-view-counter.js` and kept only the TOC initialization logic. 
- Simplified the `DOMContentLoaded` handler to initialize the TOC without attempting to mount or fetch page-view data.

### Testing

- Confirmed the change set by inspecting the modified files with `git diff -- _includes/metadata-hook.html assets/js/post-view-counter.js` which shows the Busuanzi removal. 
- Attempted a site build with `jekyll build`, which failed because `jekyll` is not available in the environment. 
- Served the site with `python3 -m http.server 4000` and captured a homepage screenshot via Playwright to validate the site still renders, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a76e2433908321a30f322d39192350)