### PR TITLE
Add app-ads.txt for Google AdSense

### DIFF
--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9677120965646002, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
### Motivation
- Provide an `app-ads.txt` at the repository root so Google AdSense can verify the authorized seller for the site using the provided seller declaration.

### Description
- Create `app-ads.txt` containing the single line `google.com, pub-9677120965646002, DIRECT, f08c47fec0942fa0` placed at the project root.

### Testing
- Ran `test -f app-ads.txt` to verify the file exists and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5da176e648321954c8609a777bc80)